### PR TITLE
Fix "publish --dev" comand setting incorrect version

### DIFF
--- a/src/pipedream/components.ts
+++ b/src/pipedream/components.ts
@@ -53,6 +53,9 @@ export function bumpVersion(globs: Globs) {
   });
 }
 export function setDevVersion(globs: Globs) {
-  const version = `0.0.${Math.floor(Date.now() / 1000)}`;
-  return setVersion(globs, version);
+  return changeVersion(globs, oldVersion => {
+    const versionParts = oldVersion.split('.');
+    const newVersion = `${versionParts[0] ?? 0}.${versionParts[1] ?? 0}.${Math.floor(Date.now() / 1000)}`;
+    return `version: "${newVersion}"`;
+  });
 }


### PR DESCRIPTION
Fixes `pd-scripts publish` command changing component version from `<MAJOR>.<MINOR>.<PATCH>` to `0.0.<timestamp>`. Now version is correctly changed to `<MAJOR>.<MINOR>.<timestamp>`.

Fixes #6